### PR TITLE
Skip over empty inode tables to prevent ZeroDivisionError

### DIFF
--- a/journalparser/ext4.py
+++ b/journalparser/ext4.py
@@ -464,7 +464,7 @@ class JournalParserExt4(JournalParserCommon[JournalTransactionExt4, EntryInfoExt
         data: bytes,
     ) -> Generator[tuple[int, Container, list[ExtendedAttribute]], None, None]:
         eattrs = []
-        if inode_table.head <= t_blocknr < inode_table.head + inode_table.len:
+        if inode_table.head != 0 and inode_table.head <= t_blocknr < inode_table.head + inode_table.len:
             idx = 0
             first_inode_num_in_table_block = (
                 (inode_table_num * self.s_inodes_per_group) + ((t_blocknr % inode_table.head) * (len(data) // self.s_inode_size)) + 1


### PR DESCRIPTION
Ran into a ZeroDivisionError (multiple occurances) when using this to check for some log files that got deleted, hope this fix makes sense to you. Here's the log tail:

```
    i_projid = 0
                                         
✔ Generating timeline done (4/15 transaction)

Extended attributes: []
Inode number: 3170505
Inode: Container: 
    i_mode = 41471
    i_uid = 0
    i_size_lo = 23
    i_atime = 1746728309
    i_ctime = 1746874292
    i_mtime = 1746728309
    i_dtime = 1746874292
    i_gid = 0
    i_links_count = 0
    i_blocks_lo = 0
    i_flags = 0
    i_osd1 = Container: 
        l_i_version = 1
    i_block = b'\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00'... (truncated, total 60)
    i_generation = 1389612303
    i_file_acl_lo = 0
    i_size_high = 0
    i_obso_faddr = 0
    i_osd2 = Container: 
        l_i_blocks_high = 0
        l_i_file_acl_high = 0
        l_i_uid_high = 0
        l_i_gid_high = 0
        l_i_checksum_lo = 51581
        l_i_reserved = 0
    i_extra_isize = 32
    i_checksum_hi = 25315
    i_ctime_extra = 2573180012
    i_mtime_extra = 3587368888
    i_atime_extra = 3587368888
    i_crtime = 1746728309
    i_crtime_extra = 3587368888
    i_version_hi = 0
    i_projid = 0
Extended attributes: []
Inode number: 3170506
Inode: Container: 
    i_mode = 33188
    i_uid = 0
    i_size_lo = 0
    i_atime = 1746728221
    i_ctime = 1746874292
    i_mtime = 1746874292
    i_dtime = 1746874292
    i_gid = 0
    i_links_count = 0
    i_blocks_lo = 0
    i_flags = 524288
    i_osd1 = Container: 
        l_i_version = 4
    i_block = b'\n\xf3\x00\x00\x04\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00'... (truncated, total 60)
    i_generation = 4263888503
    i_file_acl_lo = 0
    i_size_high = 0
    i_obso_faddr = 0
    i_osd2 = Container: 
        l_i_blocks_high = 0
        l_i_file_acl_high = 0
        l_i_uid_high = 0
        l_i_gid_high = 0
        l_i_checksum_lo = 9166
        l_i_reserved = 0
    i_extra_isize = 32
    i_checksum_hi = 61822
    i_ctime_extra = 2237177948
    i_mtime_extra = 2237177948
    i_atime_extra = 3217533000
    i_crtime = 1746728221
    i_crtime_extra = 3217533000
    i_version_hi = 0
    i_projid = 0
Extended attributes: []
Inode number: 3170507
Inode: Container: 
    i_mode = 41471
    i_uid = 0
    i_size_lo = 23
    i_atime = 1746728309
    i_ctime = 1746874292
    i_mtime = 1746728309
    i_dtime = 1746874292
    i_gid = 0
    i_links_count = 0
    i_blocks_lo = 0
    i_flags = 0
    i_osd1 = Container: 
        l_i_version = 1
    i_block = b'\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00'... (truncated, total 60)
    i_generation = 3102827888
    i_file_acl_lo = 0
    i_size_high = 0
    i_obso_faddr = 0
    i_osd2 = Container: 
        l_i_blocks_high = 0
        l_i_file_acl_high = 0
        l_i_uid_high = 0
        l_i_gid_high = 0
        l_i_checksum_lo = 51890
        l_i_reserved = 0
    i_extra_isize = 32
    i_checksum_hi = 28202
    i_ctime_extra = 2557179912
    i_mtime_extra = 3587368888
    i_atime_extra = 3587368888
    i_crtime = 1746728309
    i_crtime_extra = 3587368888
    i_version_hi = 0
    i_projid = 0
Extended attributes: []
Inode number: 3170508
Inode: Container: 
    i_mode = 33188
    i_uid = 0
    i_size_lo = 0
    i_atime = 1677713807
    i_ctime = 1746874331
    i_mtime = 1746874331
    i_dtime = 1746874331
    i_gid = 0
    i_links_count = 0
    i_blocks_lo = 0
    i_flags = 524288
    i_osd1 = Container: 
        l_i_version = 1
    i_block = b'\n\xf3\x00\x00\x04\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00'... (truncated, total 60)
    i_generation = 2072386518
    i_file_acl_lo = 0
    i_size_high = 0
    i_obso_faddr = 0
    i_osd2 = Container: 
        l_i_blocks_high = 0
        l_i_file_acl_high = 0
        l_i_uid_high = 0
        l_i_gid_high = 0
        l_i_checksum_lo = 13422
        l_i_reserved = 0
    i_extra_isize = 32
    i_checksum_hi = 501
    i_ctime_extra = 1726134612
    i_mtime_extra = 1726134612
    i_atime_extra = 2404468520
    i_crtime = 1677713807
    i_crtime_extra = 2404468520
    i_version_hi = 0
    i_projid = 0
Extended attributes: []
Inode number: 3170509
Inode: Container: 
    i_mode = 16877
    i_uid = 0
    i_size_lo = 0
    i_atime = 1746728221
    i_ctime = 1746874331
    i_mtime = 1746874331
    i_dtime = 1746874331
    i_gid = 0
    i_links_count = 0
    i_blocks_lo = 0
    i_flags = 524288
    i_osd1 = Container: 
        l_i_version = 21
    i_block = b'\n\xf3\x00\x00\x04\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00'... (truncated, total 60)
    i_generation = 596042468
    i_file_acl_lo = 0
    i_size_high = 0
    i_obso_faddr = 0
    i_osd2 = Container: 
        l_i_blocks_high = 0
        l_i_file_acl_high = 0
        l_i_uid_high = 0
        l_i_gid_high = 0
        l_i_checksum_lo = 53876
        l_i_reserved = 0
    i_extra_isize = 32
    i_checksum_hi = 6281
    i_ctime_extra = 2366138544
    i_mtime_extra = 2366138544
    i_atime_extra = 0
    i_crtime = 1746728221
    i_crtime_extra = 3313533496
    i_version_hi = 0
    i_projid = 0
Extended attributes: []
Inode number: 3170510
Inode: Container: 
    i_mode = 33188
    i_uid = 0
    i_size_lo = 0
    i_atime = 1746728221
    i_ctime = 1746874331
    i_mtime = 1746874331
    i_dtime = 1746874331
    i_gid = 0
    i_links_count = 0
    i_blocks_lo = 0
    i_flags = 524288
    i_osd1 = Container: 
        l_i_version = 4
    i_block = b'\n\xf3\x00\x00\x04\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00'... (truncated, total 60)
    i_generation = 1779127753
    i_file_acl_lo = 0
    i_size_high = 0
    i_obso_faddr = 0
    i_osd2 = Container: 
        l_i_blocks_high = 0
        l_i_file_acl_high = 0
        l_i_uid_high = 0
        l_i_gid_high = 0
        l_i_checksum_lo = 62880
        l_i_reserved = 0
    i_extra_isize = 32
    i_checksum_hi = 10538
    i_ctime_extra = 2366138544
    i_mtime_extra = 2366138544
    i_atime_extra = 0
    i_crtime = 1746728221
    i_crtime_extra = 3313533496
    i_version_hi = 0
    i_projid = 0
Extended attributes: []
Inode number: 3170511
Inode: Container: 
    i_mode = 33188
    i_uid = 0
    i_size_lo = 0
    i_atime = 1746728221
    i_ctime = 1746874331
    i_mtime = 1746874331
    i_dtime = 1746874331
    i_gid = 0
    i_links_count = 0
    i_blocks_lo = 0
    i_flags = 524288
    i_osd1 = Container: 
        l_i_version = 4
    i_block = b'\n\xf3\x00\x00\x04\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00'... (truncated, total 60)
    i_generation = 814404589
    i_file_acl_lo = 0
    i_size_high = 0
    i_obso_faddr = 0
    i_osd2 = Container: 
        l_i_blocks_high = 0
        l_i_file_acl_high = 0
        l_i_uid_high = 0
        l_i_gid_high = 0
        l_i_checksum_lo = 61885
        l_i_reserved = 0
    i_extra_isize = 32
    i_checksum_hi = 42595
    i_ctime_extra = 2366138544
    i_mtime_extra = 2366138544
    i_atime_extra = 0
    i_crtime = 1746728221
    i_crtime_extra = 3313533496
    i_version_hi = 0
    i_projid = 0
Extended attributes: []
Inode number: 3170512
Inode: Container: 
    i_mode = 33188
    i_uid = 0
    i_size_lo = 0
    i_atime = 1746728221
    i_ctime = 1746874331
    i_mtime = 1746874331
    i_dtime = 1746874331
    i_gid = 0
    i_links_count = 0
    i_blocks_lo = 0
    i_flags = 524288
    i_osd1 = Container: 
        l_i_version = 4
    i_block = b'\n\xf3\x00\x00\x04\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00'... (truncated, total 60)
    i_generation = 3991953598
    i_file_acl_lo = 0
    i_size_high = 0
    i_obso_faddr = 0
    i_osd2 = Container: 
        l_i_blocks_high = 0
        l_i_file_acl_high = 0
        l_i_uid_high = 0
        l_i_gid_high = 0
        l_i_checksum_lo = 59537
        l_i_reserved = 0
    i_extra_isize = 32
    i_checksum_hi = 9693
    i_ctime_extra = 2366138544
    i_mtime_extra = 2366138544
    i_atime_extra = 0
    i_crtime = 1746728221
    i_crtime_extra = 3329533584
    i_version_hi = 0
    i_projid = 0
Extended attributes: []
Block tag: Container: 
    t_blocknr = 131596289
    t_flags = 2
    t_blocknr_high = 0
    t_checksum = 2371308980
Directory entry:
_parse_directory_entries Exception StreamError
Block tag: Container: 
    t_blocknr = 63
    t_flags = 2
    t_blocknr_high = 0
    t_checksum = 291749565
Traceback (most recent call last):
  File "/usr/src/repos/fjta/fjta.py", line 127, in <module>
    sys.exit(main())
             ~~~~^^
  File "/usr/src/repos/fjta/fjta.py", line 123, in main
    return run(args)
  File "/usr/src/repos/fjta/fjta.py", line 117, in run
    parser.timeline()
    ~~~~~~~~~~~~~~~^^
  File "/usr/src/repos/fjta/journalparser/journalparser.py", line 195, in timeline
    self.journal_parser.timeline()
    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~^^
  File "/usr/src/repos/fjta/journalparser/common.py", line 1065, in timeline
    event_count = self.emit_timeline_events(events)
  File "/usr/src/repos/fjta/journalparser/common.py", line 1054, in emit_timeline_events
    for event in events:
                 ^^^^^^
  File "/usr/src/repos/fjta/journalparser/ext4.py", line 726, in infer_timeline_events
    for transaction in self.progress_iter(transactions, total=transaction_total, desc="Generating timeline", unit="transaction"):
                       ~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/src/repos/fjta/journalparser/common.py", line 506, in progress_iter
    for item in iterable:
                ^^^^^^^^
  File "/usr/src/repos/fjta/journalparser/ext4.py", line 719, in <genexpr>
    transactions = (self._parse_transaction(block_num) for block_num in self.transaction_start_blocks)
                    ~~~~~~~~~~~~~~~~~~~~~~~^^^^^^^^^^^
  File "/usr/src/repos/fjta/journalparser/ext4.py", line 609, in _parse_transaction
    for inode_num, inode, eattrs in self._parse_inode_table(t_blocknr, inode_table_num, inode_table, data_block):
                                    ~~~~~~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/src/repos/fjta/journalparser/ext4.py", line 470, in _parse_inode_table
    (inode_table_num * self.s_inodes_per_group) + ((t_blocknr % inode_table.head) * (len(data) // self.s_inode_size)) + 1
                                                    ~~~~~~~~~~^~~~~~~~~~~~~~~~~~
ZeroDivisionError: integer modulo by zero
+ exit status: 1
```

Also, thanks for the nice tool and good documentation! seems to work well (even though I couldn't get hold of them log files because deleting a large chroot just overruns the journal).. the output format is great as well. Kudos! :+1: :smiley: 